### PR TITLE
Fixed relpath incorrectly trims file names which contains dot in name.

### DIFF
--- a/src/IndexManifest.ts
+++ b/src/IndexManifest.ts
@@ -31,7 +31,7 @@ export default class IndexManifest {
 		const names = this.getFilenames(patterns)
 
 		const lines = names.map(name => {
-			const nameWithoutExtension = name.replace(/\..*?$/, '')
+			const nameWithoutExtension = name.replace(/\.[^.]*?$/, '')
 
 			const interpolator = new Interpolator({quotes})
 			const variable = lazyCamelCase(nameWithoutExtension)


### PR DESCRIPTION
Hey
I modified regex that trims filenames so it can handle dots correctly.
Thanks for your awesome work.